### PR TITLE
ツイート投稿に関する画面と機能を実装

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@emotion/styled": "^11.11.0",
     "@types/axios": "^0.14.0",
     "@types/axios-case-converter": "^0.4.0",
+    "@types/react-icons": "^3.0.0",
     "@types/react-router-dom": "^5.3.3",
     "axios": "^1.4.0",
     "axios-case-converter": "^1.1.0",
@@ -26,6 +27,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-hook-form": "^7.45.1",
+    "react-icons": "^4.10.1",
     "react-router-dom": "^6.14.1",
     "vite-tsconfig-paths": "^4.2.0"
   },

--- a/src/components/form/FormInput.tsx
+++ b/src/components/form/FormInput.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import { useState } from "react";
 import {
   FormControl,
   FormErrorMessage,
@@ -7,41 +7,51 @@ import {
   Input,
   InputRightElement,
   Button,
+  Textarea,
 } from "@chakra-ui/react";
 import { UseFormRegisterReturn } from "react-hook-form";
 
 type FormInputProps = {
   type?: string;
-  label: string;
+  label?: string | React.ReactNode;
+  placeholder?: string;
   register: UseFormRegisterReturn;
   error: string | undefined;
 };
 
 export const FormInput: React.FC<FormInputProps> = ({
   type = undefined,
-  label,
+  label = undefined,
+  placeholder = undefined,
   register,
   error,
 }) => {
-  const [show, setShow] = React.useState(false);
+  const [show, setShow] = useState(false);
   const handleClick = () => setShow(!show);
 
   return (
     <FormControl isInvalid={!!error}>
-      <FormLabel>{label}</FormLabel>
-      <InputGroup>
-        <Input
-          {...register}
-          type={type === "password" ? (show ? "text" : "password") : type}
-        />
-        {type === "password" && (
-          <InputRightElement width="4.5rem">
-            <Button h="1.75rem" size="sm" onClick={handleClick}>
-              {show ? "Hide" : "Show"}
-            </Button>
-          </InputRightElement>
-        )}
-      </InputGroup>
+      {label && <FormLabel>{label}</FormLabel>}
+      {type === "textarea" ? (
+        <Textarea {...register} placeholder={placeholder} />
+      ) : type === "file" ? (
+        <Input {...register} type="file" hidden accept="image/*" />
+      ) : (
+        <InputGroup>
+          <Input
+            {...register}
+            type={type === "password" ? (show ? "text" : "password") : type}
+            placeholder={placeholder}
+          />
+          {type === "password" && (
+            <InputRightElement width="4.5rem">
+              <Button h="1.75rem" size="sm" onClick={handleClick}>
+                {show ? "Hide" : "Show"}
+              </Button>
+            </InputRightElement>
+          )}
+        </InputGroup>
+      )}
       <FormErrorMessage>{error}</FormErrorMessage>
     </FormControl>
   );

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,0 +1,26 @@
+import { Container, Box, Flex } from "@chakra-ui/react";
+import { SignOutButton } from "features/auth/views/SignOutButton";
+import { useAuth } from "features/auth/useAuth";
+import { MainButton } from "components/button/MainButton";
+
+export const Header: React.FC = () => {
+  const { isSignedIn } = useAuth();
+  return (
+    <Container maxW="container.md">
+      <Flex as="header" justifyContent="space-between" alignItems="center">
+        <MainButton link="/" fontSize="2xl">
+          Twitter Clone
+        </MainButton>
+
+        {isSignedIn ? (
+          <SignOutButton />
+        ) : (
+          <Box>
+            <MainButton link="/auth/SignIn">ログイン</MainButton>
+            <MainButton link="/auth/SignUp">アカウント新規登録</MainButton>
+          </Box>
+        )}
+      </Flex>
+    </Container>
+  );
+};

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -1,0 +1,31 @@
+import { Stack } from "@chakra-ui/react";
+import { MainButton } from "components/button/MainButton";
+import { useLocation } from "react-router-dom";
+
+const SidebarList = [
+  { name: "ホーム", link: "/home" },
+  { name: "通知", link: "/notification" },
+  { name: "メッセージ", link: "/message" },
+  { name: "ブックマーク", link: "/bookmark" },
+  { name: "プロフィール", link: "/profile" },
+];
+
+export const Sidebar: React.FC = () => {
+  const location = useLocation();
+
+  return (
+    <Stack as="nav" spacing={4} w="250px" pr="8">
+      {SidebarList.map((item) => (
+        <MainButton
+          link={item.link}
+          justifyContent="start"
+          colorScheme="gray"
+          variant={location.pathname === item.link ? "solid" : "ghost"}
+          key={item.name}
+        >
+          {item.name}
+        </MainButton>
+      ))}
+    </Stack>
+  );
+};

--- a/src/features/auth/views/SignOutButton.tsx
+++ b/src/features/auth/views/SignOutButton.tsx
@@ -26,7 +26,7 @@ export const SignOutButton: React.FC = () => {
   };
 
   return (
-    <MainButton variant="solid" isLoading={isLoading} onClick={handleClick}>
+    <MainButton isLoading={isLoading} onClick={handleClick} colorScheme="gray">
       ログアウト
     </MainButton>
   );

--- a/src/features/tweet/tweetApis.tsx
+++ b/src/features/tweet/tweetApis.tsx
@@ -7,7 +7,8 @@ export const postTweet = async (params: TweetParams) => {
   const { content, image } = params;
   try {
     const res = await apiClient.post<Tweet>("tweets", { content });
-    if (!image) {
+    console.log(image);
+    if (!image || image.length === 0) {
       return res;
     } else {
       const tweetId = res.data.id;

--- a/src/features/tweet/tweetApis.tsx
+++ b/src/features/tweet/tweetApis.tsx
@@ -13,7 +13,8 @@ export const postTweet = async (params: TweetParams) => {
     } else {
       const tweetId = res.data.id;
       const formData = new FormData();
-      formData.append("tweet_id", tweetId.toString());
+      formData.append("imageable_type", "tweet");
+      formData.append("imageable_id", tweetId.toString());
       formData.append("image", image[0], image[0].name);
       const resImg = await apiClient.post(`images`, formData, {
         headers: {

--- a/src/features/tweet/tweetApis.tsx
+++ b/src/features/tweet/tweetApis.tsx
@@ -1,0 +1,28 @@
+import { Tweet } from "features/tweet/tweetTypes";
+import { apiClient } from "lib/axios/apiClient";
+
+export type TweetParams = Pick<Tweet, "content" | "image">;
+
+export const postTweet = async (params: TweetParams) => {
+  const { content, image } = params;
+  try {
+    const res = await apiClient.post<Tweet>("tweets", { content });
+    if (!image) {
+      return res;
+    } else {
+      const tweetId = res.data.id;
+      const formData = new FormData();
+      formData.append("tweet_id", tweetId.toString());
+      formData.append("image", image[0], image[0].name);
+      const resImg = await apiClient.post(`images`, formData, {
+        headers: {
+          "content-type": "multipart/form-data",
+        },
+      });
+      return resImg;
+    }
+  } catch (error) {
+    console.log(error);
+    throw error;
+  }
+};

--- a/src/features/tweet/tweetTypes.ts
+++ b/src/features/tweet/tweetTypes.ts
@@ -1,0 +1,7 @@
+export interface Tweet {
+  id: number;
+  content: string;
+  image: FileList | null;
+  createdAt: Date;
+  updatedAt: Date;
+}

--- a/src/features/tweet/views/PostTweetForm.tsx
+++ b/src/features/tweet/views/PostTweetForm.tsx
@@ -1,0 +1,123 @@
+import { Stack, Flex, Icon, Image, Box } from "@chakra-ui/react";
+import { useForm, SubmitHandler } from "react-hook-form";
+import { TweetParams } from "features/tweet/tweetApis";
+import { MainButton } from "components/button/MainButton";
+import { FormInput } from "components/form/FormInput";
+import { useToastMessage } from "hooks/useToastMessage";
+import { useState, useEffect } from "react";
+import { postTweet } from "features/tweet/tweetApis";
+import { AiFillPicture, AiFillCloseCircle } from "react-icons/ai";
+
+const checkFileSize = (value: FileList | null) => {
+  const MAX_FILE_SIZE = 2 * 1024 * 1024;
+  if (!value) return true;
+  const file = value[0];
+  if (file.size > MAX_FILE_SIZE) {
+    return "ファイルサイズは2MB以下にしてください。";
+  }
+  return true;
+};
+
+export const PostTweetForm: React.FC = () => {
+  const [isLoading, setIsLoading] = useState(false);
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+
+  const { toastMessage } = useToastMessage();
+  const {
+    register,
+    handleSubmit,
+    watch,
+    setValue,
+    reset,
+    formState: { errors },
+  } = useForm<TweetParams>();
+
+  const { image } = watch();
+  useEffect(() => {
+    if (image && image[0]) {
+      setPreviewUrl(URL.createObjectURL(image[0]));
+    } else {
+      setPreviewUrl(null);
+    }
+  }, [image]);
+
+  const onRemoveImage = () => {
+    setValue("image", null);
+    setPreviewUrl(null);
+  };
+
+  const onSubmit: SubmitHandler<TweetParams> = async (form) => {
+    try {
+      setIsLoading(true);
+      await postTweet(form);
+      toastMessage({ title: "ツイートできました" });
+      reset();
+    } catch (error) {
+      toastMessage({ title: `ツイートに失敗しました`, status: "error" });
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <Stack as="form" spacing="4" w="100%" onSubmit={handleSubmit(onSubmit)}>
+      <FormInput
+        placeholder="今どうしてる？"
+        type="textarea"
+        register={register("content", {
+          required: "必須項目です",
+          maxLength: { value: 140, message: "140文字以内で入力してください" },
+        })}
+        error={errors.content?.message}
+      />
+      {previewUrl && (
+        <Box position="relative">
+          <Image src={previewUrl} alt="preview" rounded="2xl" />
+          <Icon
+            onClick={onRemoveImage}
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+            as={AiFillCloseCircle}
+            cursor="pointer"
+            position="absolute"
+            top="-1rem"
+            right="-1rem"
+            w="8"
+            h="8"
+          />
+        </Box>
+      )}
+
+      <Flex justifyContent="space-between">
+        <Box>
+          <FormInput
+            type="file"
+            label={
+              <Icon
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+                as={AiFillPicture}
+                w={6}
+                h={6}
+                color="blue.500"
+                cursor="pointer"
+              />
+            }
+            register={register("image", {
+              validate: {
+                checkFileSize,
+              },
+            })}
+            error={errors.image?.message}
+          />
+        </Box>
+        <MainButton
+          type="submit"
+          variant="solid"
+          isLoading={isLoading}
+          size="sm"
+        >
+          ツイートする
+        </MainButton>
+      </Flex>
+    </Stack>
+  );
+};

--- a/src/features/tweet/views/PostTweetForm.tsx
+++ b/src/features/tweet/views/PostTweetForm.tsx
@@ -10,7 +10,7 @@ import { AiFillPicture, AiFillCloseCircle } from "react-icons/ai";
 
 const checkFileSize = (value: FileList | null) => {
   const MAX_FILE_SIZE = 2 * 1024 * 1024;
-  if (!value) return true;
+  if (!value || value.length === 0) return true;
   const file = value[0];
   if (file.size > MAX_FILE_SIZE) {
     return "ファイルサイズは2MB以下にしてください。";

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,9 +1,9 @@
-import { HeadingH1 } from "components/heading/HeadingH1";
+import { PostTweetForm } from "features/tweet/views/PostTweetForm";
 
 export const Home: React.FC = () => {
   return (
     <>
-      <HeadingH1>ホームページ（ログイン後のみ）</HeadingH1>
+      <PostTweetForm />
     </>
   );
 };

--- a/src/pages/Layout.tsx
+++ b/src/pages/Layout.tsx
@@ -1,21 +1,20 @@
-import { Box, Container, VStack } from "@chakra-ui/react";
+import { Box, Container, VStack, Stack, Flex } from "@chakra-ui/react";
 import { Outlet } from "react-router-dom";
-import { SignOutButton } from "features/auth/views/SignOutButton";
-import { useAuth } from "features/auth/useAuth";
+import { Header } from "components/layout/Header";
+import { Sidebar } from "components/layout/Sidebar";
 
 export const Layout: React.FC = () => {
-  const { currentUser } = useAuth();
   return (
     <>
-      <Box as="main" bg="white">
-        <Container>
-          <SignOutButton />
-          <p>{currentUser?.name}さん、ようこそ</p>
-          <VStack spacing={4} mt="12">
+      <Header />
+      <Container maxW="container.md">
+        <Flex mt="12">
+          <Sidebar />
+          <VStack as="main" spacing={4} flex="1">
             <Outlet />
           </VStack>
-        </Container>
-      </Box>
+        </Flex>
+      </Container>
     </>
   );
 };

--- a/src/pages/Page404.tsx
+++ b/src/pages/Page404.tsx
@@ -1,0 +1,9 @@
+import { Text } from "@chakra-ui/react";
+
+export const Page404: React.FC = () => {
+  return (
+    <>
+      <Text>ページが存在しません。</Text>
+    </>
+  );
+};

--- a/src/pages/Router.tsx
+++ b/src/pages/Router.tsx
@@ -1,5 +1,6 @@
 import { useEffect } from "react";
 import { Routes, Route } from "react-router-dom";
+import { Navigate } from "react-router-dom";
 import { AuthLayout } from "pages/auth/AuthLayout";
 import { Layout } from "pages/Layout";
 import { useAuth } from "features/auth/useAuth";
@@ -7,6 +8,7 @@ import { SignUp } from "pages/auth/SignUp";
 import { SignIn } from "pages/auth/SignIn";
 import { Home } from "pages/Home";
 import { PrivateRouter } from "components/router/PrivateRouter";
+import { Page404 } from "pages/Page404";
 
 export const Router: React.FC = () => {
   const { handleGetCurrentUser, isSignedIn } = useAuth();
@@ -17,6 +19,7 @@ export const Router: React.FC = () => {
   return (
     <>
       <Routes>
+        <Route path="/" element={<Navigate to="/home" />} />
         <Route path="auth" element={<AuthLayout />}>
           <Route path="signUp" element={<SignUp />} />
           <Route path="signIn" element={<SignIn />} />
@@ -30,6 +33,10 @@ export const Router: React.FC = () => {
           }
         >
           <Route path="home" element={<Home />} />
+        </Route>
+
+        <Route element={<Layout />}>
+          <Route path="*" element={<Page404 />} />
         </Route>
       </Routes>
     </>

--- a/src/pages/auth/AuthLayout.tsx
+++ b/src/pages/auth/AuthLayout.tsx
@@ -1,19 +1,16 @@
-import { Box, Container, VStack } from "@chakra-ui/react";
-import { MainButton } from "components/button/MainButton";
+import { Container, VStack } from "@chakra-ui/react";
 import { Outlet } from "react-router-dom";
+import { Header } from "components/layout/Header";
 
 export const AuthLayout: React.FC = () => {
   return (
     <>
-      <Box as="main" bg="white">
-        <Container>
-          <MainButton link="/auth/SignIn">ログイン</MainButton>
-          <MainButton link="/auth/SignUp">アカウント新規登録</MainButton>
-          <VStack spacing={4} mt="12">
-            <Outlet />
-          </VStack>
-        </Container>
-      </Box>
+      <Header />
+      <Container>
+        <VStack as="main" spacing={4} mt="12">
+          <Outlet />
+        </VStack>
+      </Container>
     </>
   );
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1426,6 +1426,13 @@
   dependencies:
     "@types/react" "*"
 
+"@types/react-icons@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@types/react-icons/-/react-icons-3.0.0.tgz#27ca2823a6add881d06a371bfff093afc1b9c829"
+  integrity sha512-Vefs6LkLqF61vfV7AiAqls+vpR94q67gunhMueDznG+msAkrYgRxl7gYjNem/kZ+as2l2mNChmF1jRZzzQQtMg==
+  dependencies:
+    react-icons "*"
+
 "@types/react-router-dom@^5.3.3":
   version "5.3.3"
   resolved "https://registry.yarnpkg.com/@types/react-router-dom/-/react-router-dom-5.3.3.tgz#e9d6b4a66fcdbd651a5f106c2656a30088cc1e83"
@@ -2833,6 +2840,11 @@ react-hook-form@^7.45.1:
   version "7.45.1"
   resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-7.45.1.tgz#e352c7f4dbc7540f0756abbb4dcfd1122fecc9bb"
   integrity sha512-6dWoFJwycbuFfw/iKMcl+RdAOAOHDiF11KWYhNDRN/OkUt+Di5qsZHwA0OwsVnu9y135gkHpTw9DJA+WzCeR9w==
+
+react-icons@*, react-icons@^4.10.1:
+  version "4.10.1"
+  resolved "https://registry.yarnpkg.com/react-icons/-/react-icons-4.10.1.tgz#3f3b5eec1f63c1796f6a26174a1091ca6437a500"
+  integrity sha512-/ngzDP/77tlCfqthiiGNZeYFACw85fUjZtLbedmJ5DTlNDIwETxhwBzdOJ21zj4iJdvc0J3y7yOsX3PpxAJzrw==
 
 react-is@^16.13.1, react-is@^16.7.0:
   version "16.13.1"


### PR DESCRIPTION
## 課題のリンク
* https://github.com/happiness-chain/practice/blob/main/14.2_react/003_%E8%AA%B2%E9%A1%8C.md

## やったこと
* ツイート投稿についてAPIの繋ぎ込み、フォームを実装
* imageがある時のみ、api/v1/imagesにpostする。
* レイアウトを整えた。

## 動作確認方法
* https://sora33.github.io/hc_twitter_react_frontend/

画面のビュー
<img width="1014" alt="image" src="https://github.com/sora33/hc_twitter_react_frontend/assets/49627888/8258732c-063e-4d8a-9389-11e7d7f7ac35">

## その他
バックエンド：https://github.com/sora33/hc_twitter_rails_api/pull/3