### PR TITLE
コメント一覧機能を追加

### DIFF
--- a/src/components/loading/MainSpinner.tsx
+++ b/src/components/loading/MainSpinner.tsx
@@ -25,7 +25,7 @@ export const MainSpinner: React.FC<MainSpinnerProps> = ({ variant = "normal", ..
     );
   } else if (variant === "normal") {
     return (
-      <Flex w="100%" alignItems="center" justifyContent="center" color="blue.500" {...props}>
+      <Flex w="100%" py="4" alignItems="center" justifyContent="center" color="blue.500" {...props}>
         <Spinner />
       </Flex>
     );

--- a/src/features/comment/commentApis.tsx
+++ b/src/features/comment/commentApis.tsx
@@ -5,6 +5,16 @@ export type CommentParams = Pick<Comment, "tweetId" | "content" | "image"> & {
   image: FileList | null;
 };
 
+export const getComments = async (id: number | string) => {
+  try {
+    const res = await apiClient.get<Comment[]>(`tweets/${id}/comments`);
+    return res.data;
+  } catch (error) {
+    console.log(error);
+    throw error;
+  }
+};
+
 export const postComment = async (params: CommentParams) => {
   const { content, tweetId, image } = params;
   try {

--- a/src/features/comment/useComments.tsx
+++ b/src/features/comment/useComments.tsx
@@ -1,0 +1,74 @@
+import { getComments } from "features/comment/commentApis";
+import { useEffect, useReducer, useState } from "react";
+import { Comment } from "features/comment/commentTypes";
+import { useParams } from "react-router-dom";
+
+const initialState = {
+  data: null,
+  isLoading: false,
+  error: null,
+  isRefetching: false,
+};
+const FETCH_START = "FETCH_START";
+const FETCH_SUCCESS = "FETCH_SUCCESS";
+const FETCH_ERROR = "FETCH_ERROR";
+const REFETCH_START = "REFETCH_START";
+
+type State = {
+  data: Comment[] | null;
+  isLoading: boolean;
+  error: Error | null;
+  isRefetching: boolean;
+};
+
+type Action =
+  | { type: typeof FETCH_START }
+  | { type: typeof FETCH_SUCCESS; payload: Comment[] }
+  | { type: typeof FETCH_ERROR; payload: Error | null }
+  | { type: typeof REFETCH_START };
+
+const reducer = (state: State, action: Action): State => {
+  switch (action.type) {
+    case FETCH_START:
+      return { ...state, isLoading: true };
+    case FETCH_SUCCESS:
+      return { ...state, isLoading: false, isRefetching: false, data: action.payload };
+    case FETCH_ERROR:
+      return { ...state, isLoading: false, isRefetching: false, error: action.payload };
+    case REFETCH_START:
+      return { ...state, isRefetching: true };
+    default:
+      throw new Error("no such action type!");
+  }
+};
+
+export const useComments = () => {
+  const [state, dispatch] = useReducer(reducer, initialState);
+  const [refetch, setRefetch] = useState(false);
+  const { id: tweetId } = useParams<{ id: string }>();
+
+  const fetchComments = async (isRefetch: boolean) => {
+    dispatch({ type: isRefetch ? REFETCH_START : FETCH_START });
+    try {
+      const res = await getComments(tweetId!);
+      dispatch({ type: FETCH_SUCCESS, payload: res });
+    } catch (error) {
+      console.log(error);
+      dispatch({ type: FETCH_ERROR, payload: error as Error });
+    } finally {
+      if (isRefetch) setRefetch(false);
+    }
+  };
+
+  useEffect(() => {
+    void fetchComments(false);
+  }, [tweetId]);
+
+  useEffect(() => {
+    if (refetch) {
+      void fetchComments(true);
+    }
+  }, [refetch]);
+
+  return { ...state, setRefetch };
+};

--- a/src/features/comment/views/CommentList.tsx
+++ b/src/features/comment/views/CommentList.tsx
@@ -1,0 +1,46 @@
+import { Flex, HStack, Text, Stack, Box } from "@chakra-ui/react";
+import { MainAvatar } from "components/avatar/MainAvatar";
+import { formatDate } from "lib/functions/formatDate";
+import { MainImage } from "components/image/MainImage";
+import { Comment } from "features/comment/commentTypes";
+
+type commentListProps = {
+  comments: Comment[];
+};
+
+export const CommentList: React.FC<commentListProps> = ({ comments }) => {
+  return (
+    <Box>
+      <Text fontWeight="bold" py="2">
+        コメント一覧
+      </Text>
+      {comments?.length > 0 ? (
+        comments?.map((comment) => (
+          <Flex borderBottom="1px solid" borderColor="gray.200" py="2">
+            <MainAvatar
+              mr="4"
+              src={comment.user.avatarImage ?? ""}
+              link={`/users/${comment.user.id}`}
+            />
+            <Stack position="relative" spacing="2" flex="1">
+              <Stack spacing="2">
+                <HStack>
+                  <Text fontWeight="bold">{comment.user.name}</Text>
+                  <Text size="sm" color="gray">
+                    {formatDate(comment.createdAt)}
+                  </Text>
+                </HStack>
+                <Text whiteSpace="pre-line" lineHeight="shorter">
+                  {comment.content}
+                </Text>
+                {comment.image && <MainImage src={comment.image} />}
+              </Stack>
+            </Stack>
+          </Flex>
+        ))
+      ) : (
+        <Text fontSize="sm">コメントはありません</Text>
+      )}
+    </Box>
+  );
+};

--- a/src/features/comment/views/PostCommentForm.tsx
+++ b/src/features/comment/views/PostCommentForm.tsx
@@ -15,6 +15,7 @@ import { IconInputImage } from "components/icon/IconInputImage";
 import { Tweet } from "features/tweet/tweetTypes";
 import { User } from "features/user/userTypes";
 import { formatDate } from "lib/functions/formatDate";
+import { useComments } from "features/comment/useComments";
 
 type PostCommentFormProps = {
   tweet: Omit<Tweet, "user">;
@@ -28,6 +29,7 @@ export const PostCommentForm: React.FC<PostCommentFormProps> = ({
 }) => {
   const [isLoading, setIsLoading] = useState(false);
   const { currentUser } = useAuth();
+  const { setRefetch } = useComments();
 
   const { toastMessage } = useToastMessage();
   const {
@@ -46,6 +48,7 @@ export const PostCommentForm: React.FC<PostCommentFormProps> = ({
       await postComment({ ...form, tweetId: tweet.id });
       toastMessage({ title: "コメントできました" });
       reset();
+      setRefetch(true);
       void hundleSubmit();
     } catch (error) {
       toastMessage({ title: `コメントに失敗しました`, status: "error" });

--- a/src/features/tweet/tweetTypes.ts
+++ b/src/features/tweet/tweetTypes.ts
@@ -4,6 +4,7 @@ export interface Tweet {
   user: User;
   content: string;
   image: FileList | null;
+  commentsCount: number;
   createdAt: Date;
   updatedAt: Date;
 }

--- a/src/features/tweet/views/TweetCard.tsx
+++ b/src/features/tweet/views/TweetCard.tsx
@@ -16,6 +16,7 @@ type TweetCardProps = {
   tweetUser: Omit<User, "tweets">;
   isDeletable?: boolean;
   setRefetch?: React.Dispatch<React.SetStateAction<boolean>>;
+  setRefetchComments?: React.Dispatch<React.SetStateAction<boolean>>;
 };
 export const TweetCard: React.FC<TweetCardProps> = ({
   isTweetDetail = false,
@@ -23,6 +24,7 @@ export const TweetCard: React.FC<TweetCardProps> = ({
   tweetUser: tweetUser,
   isDeletable = false,
   setRefetch,
+  setRefetchComments,
 }) => {
   const { toastMessage } = useToastMessage();
   const image = typeof tweet.image === "string" ? tweet.image : null;
@@ -76,7 +78,11 @@ export const TweetCard: React.FC<TweetCardProps> = ({
           </Stack>
         </BooleanLink>
         <HStack justifyContent="space-between" maxW="240px">
-          <CommentButton tweet={tweet} tweetUser={tweetUser} />
+          <CommentButton
+            tweet={tweet}
+            tweetUser={tweetUser}
+            setRefetchComments={setRefetchComments}
+          />
           <TweetCardButton type="good">12</TweetCardButton>
           <TweetCardButton type="retweet">12</TweetCardButton>
         </HStack>

--- a/src/features/tweet/views/TweetCardButton.tsx
+++ b/src/features/tweet/views/TweetCardButton.tsx
@@ -12,16 +12,17 @@ type CommentButtonProps = {
 };
 export const CommentButton: React.FC<CommentButtonProps> = ({ tweet, tweetUser }) => {
   const { isOpen, onOpen, onClose } = useDisclosure();
-  const [commentCoute, setCommentCoute] = useState(11);
+  const [commentsCount, setCommentsCoute] = useState(tweet.commentsCount ?? 0);
 
   const hundleSubmit = () => {
-    setCommentCoute((commentCoute) => commentCoute + 1);
+    setCommentsCoute((commentsCount) => commentsCount + 1);
+    setRefetchComments && setRefetchComments(true);
     onClose();
   };
   return (
     <>
       <TweetCardButton type="comment" onClick={onOpen}>
-        {commentCoute}
+        {commentsCount}
       </TweetCardButton>
       <ChildrenModal isOpen={isOpen} onClose={onClose} title="コメント投稿">
         <PostCommentForm tweet={tweet} tweetUser={tweetUser} hundleSubmit={hundleSubmit} />

--- a/src/features/tweet/views/TweetCardButton.tsx
+++ b/src/features/tweet/views/TweetCardButton.tsx
@@ -9,8 +9,13 @@ import { User } from "features/user/userTypes";
 type CommentButtonProps = {
   tweet: Omit<Tweet, "user">;
   tweetUser: Omit<User, "tweets">;
+  setRefetchComments?: React.Dispatch<React.SetStateAction<boolean>>;
 };
-export const CommentButton: React.FC<CommentButtonProps> = ({ tweet, tweetUser }) => {
+export const CommentButton: React.FC<CommentButtonProps> = ({
+  tweet,
+  tweetUser,
+  setRefetchComments,
+}) => {
   const { isOpen, onOpen, onClose } = useDisclosure();
   const [commentsCount, setCommentsCoute] = useState(tweet.commentsCount ?? 0);
 

--- a/src/features/tweet/views/TweetDetail.tsx
+++ b/src/features/tweet/views/TweetDetail.tsx
@@ -3,10 +3,17 @@ import { useTweet } from "features/tweet/useTweet";
 import { MainSpinner } from "components/loading/MainSpinner";
 import { TweetCard } from "features/tweet/views/TweetCard";
 import { useParams } from "react-router-dom";
+import { CommentList } from "features/comment/views/CommentList";
+import { useComments } from "features/comment/useComments";
 
 export const TweetDetail = () => {
   const { id } = useParams<{ id: string }>();
   const { data: tweet, isLoading, error } = useTweet(Number(id));
+  const {
+    data: comments,
+    isLoading: isLoadingComments,
+    setRefetch: setRefetchComments,
+  } = useComments();
 
   if (error) {
     return <Text>{error.message}</Text>;
@@ -15,5 +22,17 @@ export const TweetDetail = () => {
     return <MainSpinner />;
   }
 
-  return <Box>{tweet && <TweetCard isTweetDetail tweet={tweet} tweetUser={tweet.user} />}</Box>;
+  return (
+    <Box>
+      {tweet && (
+        <TweetCard
+          isTweetDetail
+          tweet={tweet}
+          tweetUser={tweet.user}
+          setRefetchComments={setRefetchComments}
+        />
+      )}
+      {isLoadingComments ? <MainSpinner /> : comments && <CommentList comments={comments} />}
+    </Box>
+  );
 };


### PR DESCRIPTION
## 課題のリンク
* https://github.com/happiness-chain/practice/blob/main/14.2_react/003_%E8%AA%B2%E9%A1%8C.md

## やったこと
* コメント一覧機能について、APIの繋ぎ込みを作成
* コメント数をDBのデータで表示
* コメント投稿した時にviewを更新するように修正

## 動作確認方法
https://sora33.github.io/hc_twitter_react_frontend/home

画面のビュー
<img width="774" alt="image" src="https://github.com/sora33/hc_twitter_react_frontend/assets/49627888/335d0b2f-f9df-4ed9-8891-dff13c84f2a1">


## その他
バックエンド：https://github.com/sora33/hc_twitter_rails_api/pull/9