### PR TITLE
フォロー機能を追加

### DIFF
--- a/src/features/user/relationship/relationshipApis.tsx
+++ b/src/features/user/relationship/relationshipApis.tsx
@@ -1,0 +1,11 @@
+import { apiClient } from "lib/axios/apiClient";
+
+export const postFollow = async (userId: number) => {
+  try {
+    const res = await apiClient.post(`users/${userId}/follow`);
+    return res;
+  } catch (error) {
+    console.log(error);
+    throw error;
+  }
+};

--- a/src/features/user/userTypes.ts
+++ b/src/features/user/userTypes.ts
@@ -10,6 +10,7 @@ export interface UserBase {
   birthday: string | null;
   headerImage: string | null;
   avatarImage: string | null;
+  isFollowing: boolean;
   createdAt: Date;
   updatedAt: Date;
 }

--- a/src/features/user/views/FollowButton.tsx
+++ b/src/features/user/views/FollowButton.tsx
@@ -1,0 +1,55 @@
+import { useState } from "react";
+import { MainButton } from "components/button/MainButton";
+import { postFollow } from "features/user/relationship/relationshipApis";
+import { useToastMessage } from "hooks/useToastMessage";
+import { UserBase } from "features/user/userTypes";
+
+type FollowButtonProps = {
+  user: UserBase;
+};
+export const FollowButton: React.FC<FollowButtonProps> = ({ user }) => {
+  const { toastMessage } = useToastMessage();
+  const [isLoading, setIsLoading] = useState(false);
+  const [isHovered, setIsHovered] = useState(false);
+  const [isFollowing, setIsFollowing] = useState(user.isFollowing ?? false);
+
+  const hundleFollow = async () => {
+    setIsLoading(true);
+    try {
+      await postFollow(user.id);
+      toastMessage({ title: "フォローしました" });
+      setIsFollowing(true);
+    } catch (error) {
+      toastMessage({ title: "フォローに失敗しました", status: "error" });
+    }
+    setIsLoading(false);
+  };
+
+  const commonButtonProps = {
+    size: "sm",
+    minW: "150px",
+    variant: "outline",
+    rounded: "3xl",
+    isLoading: isLoading,
+  };
+
+  return (
+    <>
+      {isFollowing ? (
+        <MainButton
+          {...commonButtonProps}
+          colorScheme={isHovered ? "red" : "gray"}
+          onClick={() => alert("フォロー解除メソッドを実装予定")}
+          onMouseEnter={() => setIsHovered(true)}
+          onMouseLeave={() => setIsHovered(false)}
+        >
+          {isHovered ? "フォロー解除" : "フォロー中"}
+        </MainButton>
+      ) : (
+        <MainButton {...commonButtonProps} colorScheme="gray" onClick={hundleFollow}>
+          フォローする
+        </MainButton>
+      )}
+    </>
+  );
+};

--- a/src/features/user/views/FollowButton.tsx
+++ b/src/features/user/views/FollowButton.tsx
@@ -28,7 +28,6 @@ export const FollowButton: React.FC<FollowButtonProps> = ({ user }) => {
   const commonButtonProps = {
     size: "sm",
     minW: "150px",
-    variant: "outline",
     rounded: "3xl",
     isLoading: isLoading,
   };
@@ -38,6 +37,7 @@ export const FollowButton: React.FC<FollowButtonProps> = ({ user }) => {
       {isFollowing ? (
         <MainButton
           {...commonButtonProps}
+          variant="outline"
           colorScheme={isHovered ? "red" : "gray"}
           onClick={() => alert("フォロー解除メソッドを実装予定")}
           onMouseEnter={() => setIsHovered(true)}
@@ -46,7 +46,12 @@ export const FollowButton: React.FC<FollowButtonProps> = ({ user }) => {
           {isHovered ? "フォロー解除" : "フォロー中"}
         </MainButton>
       ) : (
-        <MainButton {...commonButtonProps} colorScheme="gray" onClick={hundleFollow}>
+        <MainButton
+          {...commonButtonProps}
+          variant="solid"
+          colorScheme="gray"
+          onClick={hundleFollow}
+        >
           フォローする
         </MainButton>
       )}

--- a/src/features/user/views/UserProfile.tsx
+++ b/src/features/user/views/UserProfile.tsx
@@ -3,6 +3,7 @@ import { UserBase } from "features/user/userTypes";
 import { UpdateUserForm } from "features/user/views/UpdateUserForm";
 import { MainAvatar } from "components/avatar/MainAvatar";
 import { MainButton } from "components/button/MainButton";
+import { FollowButton } from "features/user/views/FollowButton";
 import { formatDate } from "lib/functions/formatDate";
 import { ChildrenModal } from "components/modal/ChildrenModal";
 import { shortenString } from "lib/functions/shortenString";
@@ -48,12 +49,13 @@ export const UserProfile: React.FC<UserProfileProps> = ({ user, setRefetch, isMy
         src={user.avatarImage ?? ""}
         border={"4px solid white"}
       />
-
       <Box minH="10" ml="auto">
-        {isMyPage && (
+        {isMyPage ? (
           <MainButton colorScheme="gray" variant="outline" rounded="3xl" onClick={onOpen}>
             プロフィールを編集
           </MainButton>
+        ) : (
+          <FollowButton user={user} />
         )}
       </Box>
       <Stack spacing={2}>


### PR DESCRIPTION
## 課題のリンク
* https://github.com/happiness-chain/practice/blob/main/14.2_react/003_%E8%AA%B2%E9%A1%8C.md

## やったこと
* フォローボタンとAPI繋ぎ込みを実装
* フォロー状態によって、ボタンを分岐させる。

## 動作確認方法
https://sora33.github.io/hc_twitter_react_frontend/home

画面のビュー
<img width="734" alt="image" src="https://github.com/sora33/hc_twitter_react_frontend/assets/49627888/a4fc78e5-46ff-4600-bc99-8f8694327612"><img width="739" alt="image" src="https://github.com/sora33/hc_twitter_react_frontend/assets/49627888/2d08c66c-6e21-4b16-8b43-ad8480b4cccf">

## その他
バックエンド：https://github.com/sora33/hc_twitter_rails_api/pull/13